### PR TITLE
Serve docs and category tweak

### DIFF
--- a/doc/api_data.js
+++ b/doc/api_data.js
@@ -57,7 +57,7 @@ define({ "api": [
             "type": "Number",
             "optional": true,
             "field": "category",
-            "description": "<p>The category ID from which to retrieve articles.</p>"
+            "description": "<p>The category ID (slug) from which to retrieve articles.</p>"
           }
         ]
       }

--- a/doc/api_data.json
+++ b/doc/api_data.json
@@ -57,7 +57,7 @@
             "type": "Number",
             "optional": true,
             "field": "category",
-            "description": "<p>The category ID from which to retrieve articles.</p>"
+            "description": "<p>The category ID (slug) from which to retrieve articles.</p>"
           }
         ]
       }

--- a/doc/api_project.js
+++ b/doc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-12-15T04:19:19.031Z",
+    "time": "2018-12-19T04:52:16.628Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/doc/api_project.js
+++ b/doc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-12-15T04:11:30.477Z",
+    "time": "2018-12-15T04:19:19.031Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/doc/api_project.js
+++ b/doc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-12-04T01:11:12.950Z",
+    "time": "2018-12-15T04:11:30.477Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/doc/api_project.json
+++ b/doc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-12-04T01:11:12.950Z",
+    "time": "2018-12-15T04:11:30.477Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/doc/api_project.json
+++ b/doc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-12-15T04:19:19.031Z",
+    "time": "2018-12-19T04:52:16.628Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/doc/api_project.json
+++ b/doc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-12-15T04:11:30.477Z",
+    "time": "2018-12-15T04:19:19.031Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ app.get('/articles', function (req, res) {
 
   res.setHeader('Content-Type', 'application/json');
   wp_api.getArticles(articles, page, category, preview)
-    .then(data => res.send(data))
+    .then(data => typeof data.response_code === 'undefined' ? (res.send(data)) : (res.status(data.response_code), res.send(data)));
 });
 
 
@@ -46,7 +46,7 @@ app.get('/articles/:articleId', function(req, res){
 
   res.setHeader('Content-Type', 'application/json');
   wp_api.getArticle(articleId)
-    .then(data => res.send(data))
+    .then(data => typeof data.response_code === 'undefined' ? (res.send(data)) : (res.status(data.response_code), res.send(data)));
 });
 
 /**
@@ -61,7 +61,7 @@ app.get('/menu/:id', function (req, res){
 
   res.setHeader('Content-Type', 'application/json');
   wp_api.getMenu(menu_id)
-  .then(data => res.send(data))
+    .then(data => typeof data.response_code === 'undefined' ? (res.send(data)) : (res.status(data.response_code), res.send(data)));
 });
 
 

--- a/server.js
+++ b/server.js
@@ -4,9 +4,10 @@ const wp_api = require('./wordpress-service.js');
 const cors = require('cors');
 
 app.use(cors({credentials: true, origin: true}));
+app.use('/', express.static(__dirname + '/doc'));
 
 app.get('/', function(req, res){
-  res.send("Welcome to the DBK API!");
+  res.sendFile( __dirname + "/doc/index.html");
 });
 
 
@@ -18,7 +19,7 @@ app.get('/', function(req, res){
  * @apiParam  {Boolean} preview Whether to retrieve full article data or just preview data.
  * @apiParam  {Number} [per_page]  The number of articles to retrieve per page.
  * @apiParam  {Number} [page] The page of articles to retrieve.
- * @apiParam  {Number} [category] The category ID from which to retrieve articles.
+ * @apiParam  {Number} [category] The category ID (slug) from which to retrieve articles. 
  * 
  */
 app.get('/articles', function (req, res) {

--- a/wordpress-service.js
+++ b/wordpress-service.js
@@ -2,7 +2,8 @@ const fetch = require('node-fetch');
 
 const wp_url = "http://52.207.216.69";
 const all_posts_url = "http://52.207.216.69/wp-json/wp/v2/posts";
-const menu_url = "http://52.207.216.69/wp-json/wp-api-menus/v2/menus/"
+const menu_url = "http://52.207.216.69/wp-json/wp-api-menus/v2/menus/";
+const categories_url = "http://52.207.216.69/wp-json/wp/v2/categories";
 
 exports.getArticles = async function (limitArticles, page, category, prev) {
   url = all_posts_url + "?";
@@ -14,7 +15,16 @@ exports.getArticles = async function (limitArticles, page, category, prev) {
     url += "page=" + page + "&";
   }
   if (typeof category != 'undefined') {
-    url += "categories=" + category;
+    try{
+      categoryId = await getCategoryId(category);
+      url += "categories=" + categoryId;  
+      console.log(url);
+    }
+    catch (err) {
+      return JSON.stringify({
+        error: "Invalid category"
+      });
+    }
   }
   if (typeof prev != 'undefined') {
     preview = (prev === "true");
@@ -34,6 +44,11 @@ exports.getArticles = async function (limitArticles, page, category, prev) {
         "caption": featuredImage.caption.rendered
       };
     }
+
+    const slug_categories = await categoryIdsToSlugs(ele['categories']);
+    console.log(slug_categories);
+    ele['categories'] = slug_categories;
+
     if (preview) { //return only necessary fields if preview flag is enabled 
       return {
         "id": ele.id,
@@ -57,7 +72,10 @@ exports.getArticles = async function (limitArticles, page, category, prev) {
 exports.getArticle = function (articleId) {
   url = all_posts_url + "/" + articleId;
   return fetch(url)
-    .then(data => data.json());
+    .then(data => data.json())
+    .catch(e => JSON.stringify({
+      error: "Article not found"
+    }));
 }
 
 exports.getMenu = function (menuName) {
@@ -108,4 +126,28 @@ async function getAuthorName(url) {
     "name": author.name,
     "link": author.link
     };
+}
+
+async function getCategoryId(slug){
+  const req_url = categories_url + "?slug="+slug;
+  const categoryResp = await fetch(req_url);
+  const categoryObj = await categoryResp.json();
+  return categoryObj[0].id;
+}
+
+async function getCategorySlug(id){
+  const req_url = categories_url + "/"+id;
+  console.log(req_url);
+  const categoryResp = await fetch(req_url);
+  const categoryObj = await categoryResp.json();
+  console.log(categoryObj.slug);
+  return categoryObj.slug;
+}
+
+async function categoryIdsToSlugs(categoryIds) {
+  const slug_categories = categoryIds.map(async (categoryId) => {
+    const slug = await getCategorySlug(categoryId);
+    return slug;
+  });
+  return Promise.all(slug_categories);
 }

--- a/wordpress-service.js
+++ b/wordpress-service.js
@@ -6,7 +6,7 @@ const menu_url = "http://52.207.216.69/wp-json/wp-api-menus/v2/menus/";
 const categories_url = "http://52.207.216.69/wp-json/wp/v2/categories";
 
 exports.getArticles = async function (limitArticles, page, category, prev) {
-  url = all_posts_url + "?";
+  var url = all_posts_url + "?";
   preview = false;
   if (typeof limitArticles != 'undefined') {
     url += "per_page=" + limitArticles + "&";
@@ -20,9 +20,11 @@ exports.getArticles = async function (limitArticles, page, category, prev) {
       url += "categories=" + categoryId;  
     }
     catch (err) {
-      return JSON.stringify({
-        error: "Invalid category"
-      });
+      return {
+        code: "invalid_category_name",
+        message: "Invalid category name.",
+        response_code: 404
+      };
     }
   }
   if (typeof prev != 'undefined') {
@@ -72,9 +74,18 @@ exports.getArticle = function (articleId) {
   url = all_posts_url + "/" + articleId;
   return fetch(url)
     .then(data => data.json())
-    .catch(e => JSON.stringify({
-      error: "Article not found"
-    }));
+    .then(resp => {
+      if (typeof resp.code !== 'undefined' && (resp.code === 'rest_no_route' || resp.code === 'rest_post_invalid_id')){
+        return {
+          code: "article_not_found",
+          message: "Article ID not found.",
+          response_code: 404
+        };
+      }
+      else{
+        return resp;
+      }
+    });
 }
 
 exports.getMenu = function (menuName) {
@@ -96,8 +107,11 @@ exports.getMenu = function (menuName) {
       return menuObj;
     })
     .catch(e => JSON.stringify({
-      error: "Menu not found"
-    }));
+      code: "menu_not_found",
+      message: "Invalid menu ID.",
+      response_code: 404
+      
+  }));
 }
 
 function replaceMenuUrl(menuItem){

--- a/wordpress-service.js
+++ b/wordpress-service.js
@@ -18,7 +18,6 @@ exports.getArticles = async function (limitArticles, page, category, prev) {
     try{
       categoryId = await getCategoryId(category);
       url += "categories=" + categoryId;  
-      console.log(url);
     }
     catch (err) {
       return JSON.stringify({
@@ -45,9 +44,8 @@ exports.getArticles = async function (limitArticles, page, category, prev) {
       };
     }
 
-    const slug_categories = await categoryIdsToSlugs(ele['categories']);
-    console.log(slug_categories);
-    ele['categories'] = slug_categories;
+    const slug_categories = await categoryIdsToSlugs(ele.categories);
+    ele.categories = slug_categories;
 
     if (preview) { //return only necessary fields if preview flag is enabled 
       return {
@@ -57,7 +55,8 @@ exports.getArticles = async function (limitArticles, page, category, prev) {
         "date": ele.modified,
         "excerpt": ele.excerpt.rendered,
         "author": author,
-        "featured-image": featuredImage
+        "featured-image": featuredImage,
+        "categories": ele.categories
       }
     } else { //return full response with author name and featured image URL
       ele["author"] = author;
@@ -137,10 +136,8 @@ async function getCategoryId(slug){
 
 async function getCategorySlug(id){
   const req_url = categories_url + "/"+id;
-  console.log(req_url);
   const categoryResp = await fetch(req_url);
   const categoryObj = await categoryResp.json();
-  console.log(categoryObj.slug);
   return categoryObj.slug;
 }
 


### PR DESCRIPTION
API will now serve documentation when there is no endpoint specified (for now, at localhost:8080). Additionally, the article endpoint takes in a category slug instead of a numerical category ID, and it returns a list of category slugs instead of a list of category IDs. 